### PR TITLE
refactor: fix build warnings for unused 'use'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["audio", "openal"]
 exclude = ["examples/*"]
 
 [dependencies]
-thiserror = "1.0"
+thiserror = "2.0"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
-lazy_static = "1.4.0"
+lazy_static = "1.4"
 
 [dev-dependencies]
 hound = "3.4.0"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,7 +3,7 @@ use crate::{
     AllenResult, Context,
 };
 use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::FromPrimitive;
 use std::{
     ffi::{c_void, CString},
     mem::size_of,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,7 @@ pub use device::*;
 pub use listener::*;
 pub(crate) use properties::*;
 pub use source::*;
-use std::{
-    ffi::{CStr, CString},
-    ptr,
-};
+use std::ffi::CStr;
 use thiserror::Error;
 
 /// For whatever reason, macros which take type parameters can't accept "[f32; 3]"


### PR DESCRIPTION
Hi. The git version throws warnings about unused 'use' directives. This pull request fixes them.