### PR TITLE
refactor: fix warning 'hiding a lifetime that's elided elsewhere is c…

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -61,7 +61,7 @@ impl Context {
     }
 
     /// Locks the current context into self for the entire thread (if not possible, entire process).
-    pub fn make_current(&self) -> Option<MutexGuard<()>> {
+    pub fn make_current(&self) -> Option<MutexGuard<'_, ()>> {
         // Try for thread first.
         let function: PFNALCSETTHREADCONTEXTPROC = unsafe {
             let name = CString::new("alcSetThreadContext").unwrap();


### PR DESCRIPTION
This patch fixes a warning when compiled with rustc version >= 1.89

----------------------------
compiler warning:

warning: hiding a lifetime that's elided elsewhere is confusing
  --> /home/ze/local/dev/glome-full/allen/src/context.rs:64:25
   |
64 |     pub fn make_current(&self) -> Option<MutexGuard<()>> {
   |                         ^^^^^            -------------- the same lifetime is hidden here
   |                         |
   |                         the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: "#[warn(mismatched_lifetime_syntaxes)]" on by default
help: use "'_" for type paths
   |
64 |     pub fn make_current(&self) -> Option<MutexGuard<'_, ()>> {
   |                                                     +++
